### PR TITLE
updates 👌

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,13 @@
 var url = require('url');
 
 module.exports = function (x) {
-	if (x.host && x.port) {
-		x.hostname = x.host;
-		delete x.host;
+	if (typeof x !== 'object') {
+		throw new Error('Expected an object');
 	}
 
-	return url.format(x).replace(/^\/\//, '');
+	var u = new url.Url();
+	u.hostname = x.hostname || x.host;
+	u.port = x.port;
+
+	return url.format(u).replace(/^\/\//, '');
 };

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # url-format-lax [![Build Status](https://travis-ci.org/sindresorhus/url-format-lax.svg?branch=master)](https://travis-ci.org/sindresorhus/url-format-lax)
 
-> Lax [`url.format()`](https://nodejs.org/docs/latest/api/url.html#url_url_format_urlobj)
+> Lax [`url.format()`](https://nodejs.org/docs/latest/api/url.html#url_url_format_urlobj). Formats a hostname and port into IPv6-compatible socket form of `hostname:port`.
 
 
 ## Install
@@ -15,7 +15,9 @@ $ npm install --save url-format-lax
 ```js
 var urlFormatLax = require('url-format-lax');
 
-urlFormatLax({host: 'google.com', port: '123'});
+urlFormatLax({hostname: '::1', port: '123'});
+//=> '[::1]:123'
+urlFormatLax({protocol: 'https', hostname: 'google.com', port: '123'});
 //=> 'google.com:123'
 ```
 
@@ -24,8 +26,10 @@ And with the builtin `url.format()`:
 ```js
 var url = require('url');
 
-url.format({host: 'google.com', port: '123'});
-//=> '//google.com'
+url.format({hostname: '::1', port: '123'});
+//=> '//[::1]:123'
+url.format({protocol: 'https', hostname: 'google.com', port: '123'});
+//=> 'https://google.com:123'
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -4,7 +4,11 @@ var fn = require('./');
 
 test(function (t) {
 	t.is(fn({host: 'google.com', port: '123'}), 'google.com:123');
+	t.is(fn({host: 'google.com', port: 123}), 'google.com:123');
+	t.is(fn({host: 'google.com'}), 'google.com');
 	t.is(fn({host: '::', port: '123'}), '[::]:123');
-	t.is(fn({protocol: 'http:', host: 'google.com'}), 'http://google.com');
+	t.is(fn({host: '::'}), '[::]');
+	t.is(fn({protocol: 'http:', host: 'google.com'}), 'google.com');
+	t.is(fn({host: 'google.com', pathname: '/path'}), 'google.com');
 	t.end();
 });


### PR DESCRIPTION
Followup to https://github.com/sindresorhus/module-requests/issues/32.

Uses a new url object and just sets `hostname` and `port`, so any unwanted props are removed and this way, it should be the exact inverse of `url-parse-lax`.
